### PR TITLE
temporarily sort by depositors

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -326,11 +326,17 @@ const ShowShielded = ({
 }: {
   shielded: ShieldedPoolTimedSnapshots[];
 }) => {
+  /*
   const sorted = [...shielded].sort((a, b) =>
     a.now.priority === b.now.priority
       ? b.now.unique_depositors - a.now.unique_depositors
       : b.now.priority - a.now.priority,
   );
+  */
+  const sorted = [...shielded].sort((a, b) =>
+    b.now.unique_depositors - a.now.unique_depositors
+  );
+
 
   const [changeWindow, setChangeWindow] = useState("24h");
   const [depositorsWindow, setDepositorsWindow] = useState("∞");


### PR DESCRIPTION
Can be reverted after https://github.com/prax-wallet/registry/issues/105

Better to not have this be permanent because someone could just grind addresses to change the order. Not sure anyone would care to do that.