### PR TITLE
ci: add auto-deploy workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,15 +1,18 @@
 ---
 name: Create and publish container image
 on:
-  # Build on merge to main, or any tag push.
-  push:
-    branches:
-      - main
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
-  # Also support ad-hoc calls for workflow.
+  # Don't build on merge into main:
+  # instead, we'll trigger the container build via the "deploy" workflow,
+  # which runs on merge to main.
+  # push:
+  #   branches:
+  #     - main
+  #     tags:
+  #     - '**[0-9]+.[0-9]+.[0-9]+*'
+  # Also support ad-hoc and per-repo calls to trigger builds.
   workflow_call:
   workflow_dispatch:
+  repository_dispatch:
 jobs:
   penumbers:
     runs-on: buildjet-16vcpu-ubuntu-2204

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+---
+# Workflow for deploying the Insights dashboard webapp https://github.com/penumbra-zone/penumbers
+# Bounces a container deployment, to repull the latest image.
+name: deploy insights
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-container:
+    name: build container
+    uses: ./.github/workflows/container.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+
+  deploy:
+    name: deploy insights
+    env:
+      DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    needs:
+      - build-container
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
+
+      # Confirm that the nix devshell is buildable and runs at all.
+      - name: validate nix env
+        run: nix develop --command echo hello
+
+      - name: save DigitalOcean kubeconfig with short-lived credentials
+        run: >
+          nix develop --command
+          doctl kubernetes cluster kubeconfig save --expiry-seconds 600 plinfra
+
+      # We assume that dex-explorer has been deployed to the cluster already.
+      # This task merely "bounces" the service, so that a fresh container is pulled.
+      - name: deploy dex-explorer
+        run: >
+          nix develop --command
+          kubectl -n mainnet rollout restart deployment insights &&
+          nix develop --command
+          kubectl -n mainnet rollout status deployment insights


### PR DESCRIPTION
We're already building the container on merge into main. There have been a few fix-up commits pushed recently that would be nice to ship automatically, so let's bounce the deployment, pulling the new container, on merge into main.

Closes #5.