### PR TITLE
fix: unbreak metadata handling for badges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "penumbers",
       "dependencies": {
-        "@penumbra-labs/registry": "^11.3.1",
-        "@penumbra-zone/protobuf": "^6.1.0",
-        "@penumbra-zone/types": "^24.0.0",
-        "@penumbra-zone/ui": "^10.0.2",
+        "@penumbra-labs/registry": "^11.5.0",
+        "@penumbra-zone/protobuf": "^6.3.0",
+        "@penumbra-zone/types": "^26.1.0",
+        "@penumbra-zone/ui": "^12.2.1",
         "@remix-run/node": "^2.12.1",
         "@remix-run/react": "^2.12.1",
         "@remix-run/serve": "^2.12.1",
@@ -1872,32 +1872,32 @@
       }
     },
     "node_modules/@penumbra-labs/registry": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/@penumbra-labs/registry/-/registry-11.3.1.tgz",
-      "integrity": "sha512-0hBfPZW4Y3my6RzYSBGI3cwutW+C7KJXn5OLXOhhXPsH+VlexrxvKIWc8nJeUwRCTtBkRR0lUSwuIhnaw0tsyQ=="
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@penumbra-labs/registry/-/registry-11.5.0.tgz",
+      "integrity": "sha512-6EWarHV9ClyWz208T2ctbuoCH+e8RR6VemGmyVihjFHYcJP//eFAgFzH5dDtH3WVup/ron2Y0jFcsnlqGcHHDQ=="
     },
     "node_modules/@penumbra-zone/bech32m": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@penumbra-zone/bech32m/-/bech32m-8.0.0.tgz",
-      "integrity": "sha512-1MBJClwos7QGFlY/MH7HOfsY1F99FR/OqeYmkL+1NuTCEHrUENi/pS+WOx56rmVIokqSfRPj8zQCh6gd7aQVuw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@penumbra-zone/bech32m/-/bech32m-10.0.0.tgz",
+      "integrity": "sha512-VPsT7QePXBIgYUJq0ljRCdUivmYgF3oAuaQntJLGw/mXkFwB9Ly6tYr+2ZysQv4LQjujWutIiuvKITOKPtN5cA==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "bech32": "^2.0.0"
       },
       "peerDependencies": {
-        "@penumbra-zone/protobuf": "6.1.0"
+        "@penumbra-zone/protobuf": "6.3.0"
       }
     },
     "node_modules/@penumbra-zone/getters": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@penumbra-zone/getters/-/getters-18.0.0.tgz",
-      "integrity": "sha512-qd421V84hZG8ELMTKvis3WCTBwD8zi7jJm9quYSMe9UhQaJwxD6iQS4X+20w2SUoIOsDKDFc/xIMOSl9rAwSxQ==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@penumbra-zone/getters/-/getters-20.0.0.tgz",
+      "integrity": "sha512-P0Cb/woPUT6gzbQUi2hMvfQ70K09wfObZKYVl6m8X2nMPP6/vEiXN09UITpWaHb1KVqN3JDHVBMZlu85MpmLBA==",
       "license": "(MIT OR Apache-2.0)",
       "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0",
-        "@penumbra-zone/bech32m": "8.0.0",
-        "@penumbra-zone/protobuf": "6.1.0"
+        "@penumbra-zone/bech32m": "10.0.0",
+        "@penumbra-zone/protobuf": "6.3.0"
       }
     },
     "node_modules/@penumbra-zone/keys": {
@@ -1912,31 +1912,31 @@
       }
     },
     "node_modules/@penumbra-zone/perspective": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@penumbra-zone/perspective/-/perspective-32.0.0.tgz",
-      "integrity": "sha512-jedibnOvEeVzOfNaI3lOLhjLz3oNUg3bd7ER5vzPKasY2CBXGF0c7P/ps5ZQshXsI0MIoH8vKWpehmD1JLGSbA==",
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/@penumbra-zone/perspective/-/perspective-36.0.0.tgz",
+      "integrity": "sha512-JDgPjtN1bFMZQr6Wl9Syzl+FhPkuSOBDDpGBx+frSsbPUcD/YuIncsM+y4KdNPqtlJZk7+9kvD2mFvdBE8DMJQ==",
       "license": "(MIT OR Apache-2.0)",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0",
-        "@penumbra-zone/bech32m": "8.0.0",
-        "@penumbra-zone/getters": "18.0.0",
-        "@penumbra-zone/protobuf": "6.1.0",
-        "@penumbra-zone/wasm": "29.1.0"
+        "@penumbra-zone/bech32m": "10.0.0",
+        "@penumbra-zone/getters": "20.0.0",
+        "@penumbra-zone/protobuf": "6.3.0",
+        "@penumbra-zone/wasm": "32.0.0"
       }
     },
     "node_modules/@penumbra-zone/protobuf": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@penumbra-zone/protobuf/-/protobuf-6.1.0.tgz",
-      "integrity": "sha512-0aVpa0VvodqGERXRNfD0Q3VawfjH77E86e/aDIc/7FjhZB+9TGvhfVVFFBaaRWwOmueQxH2iT5IY/3p+eXQGXA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@penumbra-zone/protobuf/-/protobuf-6.3.0.tgz",
+      "integrity": "sha512-ZaApZtsXrX3GeAJEdMuKPPqnvxp74qFmL5ugOz7srP78Y6udZmLj6Gzo16bIL4JflXFYq99n+kB2jtWidPWSyQ==",
       "license": "(MIT OR Apache-2.0)",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@penumbra-zone/types": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@penumbra-zone/types/-/types-24.0.0.tgz",
-      "integrity": "sha512-iD7K0e34gVrkNvfAOoEUctFMtAfXfofynOSngNqDGqZmu3MMRmKfBFiSAfouloJpf+1lT7h92AJo1vmpUV2VIw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@penumbra-zone/types/-/types-26.1.0.tgz",
+      "integrity": "sha512-4L4txEGDN+7zsh0Tw/E81S9z3S5n3r4i0tqTE5Q7ZlCveb08DvJqU/23kTvofjveDH/jcW/dsuqEXKDAD3Nc3g==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "bignumber.js": "^9.1.2",
@@ -1945,22 +1945,22 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0",
-        "@penumbra-zone/bech32m": "8.0.0",
-        "@penumbra-zone/getters": "18.0.0",
-        "@penumbra-zone/protobuf": "6.1.0"
+        "@penumbra-zone/bech32m": "10.0.0",
+        "@penumbra-zone/getters": "20.0.0",
+        "@penumbra-zone/protobuf": "6.3.0"
       }
     },
     "node_modules/@penumbra-zone/ui": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@penumbra-zone/ui/-/ui-10.0.2.tgz",
-      "integrity": "sha512-/c3JZTLfjTaZZrqg8OCXqTTyaOCBL/5tf1v9CDJbo3MkIprnNj2DKQok9yLRrThTxGnls/gu3aVVcHFx4xcuTg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@penumbra-zone/ui/-/ui-12.2.1.tgz",
+      "integrity": "sha512-5bWomxhj14UY9T2SgYEpUQ278ljYBijHHAUFBS9NM2MHEKPaK9Q9Pr5u8jBFdwGIihDuAFLkUdGVM66xwzA1eg==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@penumbra-zone/bech32m": "8.0.0",
-        "@penumbra-zone/perspective": "32.0.0",
-        "@penumbra-zone/types": "24.0.0",
+        "@penumbra-zone/bech32m": "10.0.0",
+        "@penumbra-zone/perspective": "36.0.0",
+        "@penumbra-zone/types": "26.1.0",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-dialog": "1.0.5",
@@ -2008,7 +2008,7 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0",
-        "@penumbra-zone/protobuf": "6.1.0",
+        "@penumbra-zone/protobuf": "6.3.0",
         "framer-motion": "^11.2.4",
         "lucide-react": "^0.378.0",
         "postcss": "^8.4.38",
@@ -2027,9 +2027,9 @@
       }
     },
     "node_modules/@penumbra-zone/wasm": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/@penumbra-zone/wasm/-/wasm-29.1.0.tgz",
-      "integrity": "sha512-CPjk/sYwtETgjyg1VuKBlmGambL/bGc5VrRiwqTg7fgZZHZW7aW37Zkr4VR5X3j3j6pBD3h6wmIjJUsLeb4c+g==",
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/@penumbra-zone/wasm/-/wasm-32.0.0.tgz",
+      "integrity": "sha512-eYEyuiI6bm/r/FzcvvI364F0MRy5Lr/A7Z47E45akon8ey8uUUtgGS6ZLFloXxDccHs8N0nf5RvM2C5bE+Ob8w==",
       "license": "(MIT OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -2037,9 +2037,9 @@
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0",
-        "@penumbra-zone/bech32m": "8.0.0",
-        "@penumbra-zone/protobuf": "6.1.0",
-        "@penumbra-zone/types": "24.0.0"
+        "@penumbra-zone/bech32m": "10.0.0",
+        "@penumbra-zone/protobuf": "6.3.0",
+        "@penumbra-zone/types": "26.1.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@penumbra-labs/registry": "^11.3.1",
-    "@penumbra-zone/protobuf": "^6.1.0",
-    "@penumbra-zone/types": "^24.0.0",
-    "@penumbra-zone/ui": "^10.0.2",
+    "@penumbra-labs/registry": "^11.5.0",
+    "@penumbra-zone/protobuf": "^6.3.0",
+    "@penumbra-zone/types": "^26.1.0",
+    "@penumbra-zone/ui": "^12.2.1",
     "@remix-run/node": "^2.12.1",
     "@remix-run/react": "^2.12.1",
     "@remix-run/serve": "^2.12.1",


### PR DESCRIPTION
We recently released support for "badges" in asset metadata [0]. Since the penumbers app was pulling from the asset registry remotely, this broke the app. We should probably switch to using bundled registry data instead. For now, though, I've bumped all the Penumbra JS deps to their latest versions, which unbreaks the site.

Refs #9.