### PR TITLE
ci: add coingecko API key to deploy env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
     name: deploy insights
     env:
       DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      COINGECKO_API_KEY: ${{ secrets.ERWAN_COINGECKO_TOKEN_TMP }}
     needs:
       - build-container
     runs-on: buildjet-8vcpu-ubuntu-2204


### PR DESCRIPTION
This adds a temporary coingecko API key to deploy env. 