### PR TITLE
fix(build): ditch corepack in containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,11 @@
 # Provide specific arg for setting the version of nodejs to use.
 # Should match what's in flake.nix for development.
 ARG NODE_MAJOR_VERSION=20
+ARG PNPM_VERSION=10.2.0
 FROM docker.io/node:${NODE_MAJOR_VERSION}-alpine AS base
-RUN corepack enable pnpm
+# We no longer use `corepack enable pnpm` due to breakage documented in
+# https://github.com/nodejs/corepack/issues/612
+RUN npm install -g pnpm@${PNPM_VERSION}
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
             jq
             just
             pnpm
-            # nodejs_20
+            nodejs_20
             postgresql
 
             # for deployment/ci

--- a/justfile
+++ b/justfile
@@ -1,9 +1,13 @@
-# A justfile for dex-explorer development.
+# A justfile for Penumbra "insights" dashboard development.
 # Documents common tasks for local dev.
+
+# install node deps locally via pnpm
+install:
+  pnpm install
 
 # run the app locally with live reload, via pnpm
 dev:
-  pnpm install
+  @just install
   pnpm run dev
 
 # build container image
@@ -13,4 +17,4 @@ container:
 # run container
 run-container:
   just container
-  podman run -e PENUMBRA_INDEXER_ENDPOINT -e PENUMBRA_INDEXER_CA_CERT -p 3000:3000 -it penumbers
+  podman run -e PENUMBRA_INDEXER_ENDPOINT -e PENUMBRA_INDEXER_CA_CERT -e COINGECKO_API_KEY -p 3000:3000 -it penumbers


### PR DESCRIPTION
The deploy pipeline was failing on container builds (across the PL frontend repos) due to upstream breakage in corepack [0].

[0] https://github.com/nodejs/corepack/issues/612