### PR TITLE
insights: cache coingecko queries

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Table } from "@penumbra-zone/ui/Table";
 import type { MetaFunction } from "@remix-run/node";
 import { Database, db } from "backend/database";
+import { fetchCoinGeckoPrice } from "backend/cache/coinGeckoCache";
 import { splitLoHi } from "@penumbra-zone/types/lo-hi";
 import {
   AssetId,
@@ -24,7 +25,7 @@ import { Density } from "@penumbra-zone/ui/Density";
 import { getFormattedAmtFromValueView } from "@penumbra-zone/types/value-view";
 import { Display } from "@penumbra-zone/ui/Display";
 import { Tooltip, TooltipProvider } from "@penumbra-zone/ui/Tooltip";
-import { penumbraToCoinGeckoMap } from "../data/coingecko";
+
 import { Cone } from "lucide-react";
 
 function knownValueView(metadata: Metadata, amount: Amount): ValueView {
@@ -126,32 +127,6 @@ class Supply {
 
   static fromJson(data: Jsonified<Supply>): Supply {
     return new Supply(ValueView.fromJson(data.total), data.staked_percentage);
-  }
-}
-
-async function fetchCoinGeckoPrice(
-  metadata: Metadata
-): Promise<number | undefined> {
-  let coinGeckoId = metadata.coingeckoId;
-  if (!coinGeckoId) {
-    coinGeckoId = metadata.symbol;
-  }
-
-  try {
-    const response = await fetch(
-      `https://pro-api.coingecko.com/api/v3/simple/price?ids=${coinGeckoId}&vs_currencies=usd&x_cg_pro_api_key=${process.env.COINGECKO_API_KEY}`
-    );
-    if (!response.ok) {
-      console.error(
-        `Failed to fetch CoinGecko price for ${coinGeckoId}, status: ${response.status}`
-      );
-      return undefined;
-    }
-    const data = await response.json();
-    return data[coinGeckoId]?.usd;
-  } catch (error) {
-    console.error(`Error fetching CoinGecko price for ${coinGeckoId}:`, error);
-    return undefined;
   }
 }
 

--- a/backend/cache/coinGeckoCache.ts
+++ b/backend/cache/coinGeckoCache.ts
@@ -1,0 +1,128 @@
+import type { Metadata } from "@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb";
+
+const COINGECKO_CACHE_TTL_MS = 60 * 1000; // one minute
+
+// Small cache-aside layer for coin gecko (guecko? gekko?) prices.
+interface CacheEntry {
+  value: number | undefined;
+  expiry: number;
+}
+
+const coinGeckoCache = new Map<string, CacheEntry>();
+
+// We ONLY block if the cache is empty, but otherwise, we prefer
+// to return slightly stale values than to block the request.
+export async function fetchCoinGeckoPrice(
+  metadata: Metadata
+): Promise<number | undefined> {
+  const coinGeckoId = metadata.coingeckoId || metadata.symbol;
+  if (!coinGeckoId) return undefined;
+
+  const now = Date.now();
+  const cached = coinGeckoCache.get(coinGeckoId);
+  if (cached) {
+    if (cached.expiry > now) {
+      return cached.value;
+    } else {
+      // We return a value immediately but trigger a refresh.
+      refreshCoinGeckoPrice(coinGeckoId);
+      return cached.value;
+    }
+  }
+
+  return await fetchAndCacheCoinGeckoPrice(coinGeckoId);
+}
+
+async function fetchAndCacheCoinGeckoPrice(
+  coinGeckoId: string
+): Promise<number | undefined> {
+  const now = Date.now();
+  try {
+    const response = await fetch(
+      `https://pro-api.coingecko.com/api/v3/simple/price?ids=${coinGeckoId}&vs_currencies=usd&x_cg_pro_api_key=${process.env.COINGECKO_API_KEY}`
+    );
+    if (!response.ok) {
+      console.error(
+        `Failed to fetch CoinGecko price for ${coinGeckoId}, status: ${response.status}`
+      );
+      coinGeckoCache.set(coinGeckoId, {
+        value: undefined,
+        expiry: now + COINGECKO_CACHE_TTL_MS,
+      });
+      return undefined;
+    }
+    const data = await response.json();
+    const price = data[coinGeckoId]?.usd;
+    coinGeckoCache.set(coinGeckoId, {
+      value: price,
+      expiry: now + COINGECKO_CACHE_TTL_MS,
+    });
+    return price;
+  } catch (error) {
+    console.error(`Error fetching CoinGecko price for ${coinGeckoId}:`, error);
+    coinGeckoCache.set(coinGeckoId, {
+      value: undefined,
+      expiry: now + COINGECKO_CACHE_TTL_MS,
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Fires off a background refresh of the CoinGecko price.
+ * Duplicate refreshes are not prevented in this implementation, but eh. probably fine.
+ */
+function refreshCoinGeckoPrice(coinGeckoId: string) {
+  (async () => {
+    const now = Date.now();
+    try {
+      const response = await fetch(
+        `https://pro-api.coingecko.com/api/v3/simple/price?ids=${coinGeckoId}&vs_currencies=usd&x_cg_pro_api_key=${process.env.COINGECKO_API_KEY}`
+      );
+      if (!response.ok) {
+        console.error(
+          `Failed to refresh CoinGecko price for ${coinGeckoId}, status: ${response.status}`
+        );
+        coinGeckoCache.set(coinGeckoId, {
+          value: undefined,
+          expiry: now + COINGECKO_CACHE_TTL_MS,
+        });
+        return;
+      }
+      const data = await response.json();
+      const price = data[coinGeckoId]?.usd;
+      coinGeckoCache.set(coinGeckoId, {
+        value: price,
+        expiry: now + COINGECKO_CACHE_TTL_MS,
+      });
+    } catch (error) {
+      console.error(
+        `Error refreshing CoinGecko price for ${coinGeckoId}:`,
+        error
+      );
+      coinGeckoCache.set(coinGeckoId, {
+        value: undefined,
+        expiry: now + COINGECKO_CACHE_TTL_MS,
+      });
+    }
+  })();
+}
+
+/**
+ * We kick off a refresh every 30 minutes for all keys in the cache.
+ * That way we don't return horribly stale information on cold loads.
+ */
+function scheduleCacheRefreshCron() {
+  setInterval(() => {
+    const keys = Array.from(coinGeckoCache.keys());
+    if (keys.length === 0) return; // Nothing to refresh yet.
+    console.log(
+      `Refresh: updating CoinGecko cache for keys: ${keys.join(", ")}`
+    );
+    keys.forEach((id) => {
+      fetchAndCacheCoinGeckoPrice(id).catch((err) => console.error(err));
+    });
+  }, 30 * 60 * 1000); // 30 min
+}
+
+scheduleCacheRefreshCron();


### PR DESCRIPTION
This adds a simple cache aside so that:
- We only make a query to CG if an entry is stale (TTL > 60s)
- We immediately return cache hits if an entry is stale
- We background refresh the cache every 30min so that stale entries ~ track reference prices